### PR TITLE
ci(android): fail loudly instead of reporting a false "no API change"

### DIFF
--- a/.github/workflows/automatic-detect-sdk-updates.yml
+++ b/.github/workflows/automatic-detect-sdk-updates.yml
@@ -45,6 +45,12 @@ jobs:
           VERSION=$(sed -n -E \
             's|.*<AndroidMavenLibrary +Include="com\.microsoft\.clarity:clarity" +Version="([^"]+)".*|\1|p' \
             src/Maui.MicrosoftClarity.Android/Maui.MicrosoftClarity.Android.csproj | head -1)
+          # An empty parse would compare unequal to every upstream version and open a
+          # bogus auto-bump PR on every daily run, so treat it as fatal.
+          if [[ -z "$VERSION" ]]; then
+            echo "ERROR: could not parse the pinned Clarity version from the binding csproj" >&2
+            exit 1
+          fi
           echo "Current pinned native: $VERSION"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 

--- a/scripts/bump-android.sh
+++ b/scripts/bump-android.sh
@@ -54,6 +54,18 @@ sed -i.bak -E \
   "$ANDROID_CSPROJ"
 rm -f "${ANDROID_CSPROJ}.bak"
 
+# Read the pin back. If this write ever silently misses while the read in step 1
+# still matches, the steps below would bump the NuGet version and the wrapper
+# reference while leaving the native pin behind — i.e. ship "3.9.0.0" containing
+# Clarity 3.8.2.
+WRITTEN_NATIVE=$(sed -n -E \
+  's|.*<AndroidMavenLibrary +Include="com\.microsoft\.clarity:clarity" +Version="([^"]+)".*|\1|p' \
+  "$ANDROID_CSPROJ" | head -1)
+if [[ "$WRITTEN_NATIVE" != "$NEW_VERSION" ]]; then
+  echo "ERROR: failed to update the <AndroidMavenLibrary> pin (still '${WRITTEN_NATIVE}')" >&2
+  exit 1
+fi
+
 # --- 4. Update <Version> in the binding csproj ------------------------------
 # Versioning rule: <native>.<binding-rev>; reset rev to .0 on native bump.
 CURRENT_BINDING_VERSION=$(sed -n -E 's|.*<Version>([^<]+)</Version>.*|\1|p' "$ANDROID_CSPROJ" | head -1)

--- a/scripts/bump-android.sh
+++ b/scripts/bump-android.sh
@@ -43,7 +43,9 @@ echo "    target  native version: $NEW_VERSION"
 # The AAR is only fetched at build time, so a typo here would otherwise surface
 # as an opaque XA4234 much later in the pipeline.
 echo "==> Verifying $POM_URL"
-if ! curl -fsSL -o /dev/null "$POM_URL"; then
+# --retry (without --retry-all-errors) covers timeouts/429/5xx but not the 404 we are
+# actually testing for, so a missing version still fails on the first attempt.
+if ! curl -fsSL --retry 3 --retry-delay 2 -o /dev/null "$POM_URL"; then
   echo "ERROR: com.microsoft.clarity:clarity:${NEW_VERSION} not found on Maven Central" >&2
   exit 1
 fi

--- a/scripts/diff-binding-api.sh
+++ b/scripts/diff-binding-api.sh
@@ -40,6 +40,11 @@ WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 DIFF_PATH="api-diff.txt"
 
+# Retries transient faults only. Without --retry-all-errors, curl retries timeouts,
+# 408, 429 and 5xx but not a 404, so a genuinely absent artifact still fails on the
+# first attempt instead of burning three round-trips.
+CURL_RETRY=(--retry 3 --retry-delay 2)
+
 emit_outputs() {
   local added="$1" removed="$2" path="$3"
   echo "==> Outputs"
@@ -73,7 +78,7 @@ case "$PLATFORM" in
 
     OLD_ZIP_URL="https://www.clarity.ms/apps/resources/ios/Clarity-${PREVIOUS_NATIVE}.xcframework.zip"
     echo "==> Downloading previous xcframework: $OLD_ZIP_URL"
-    if ! curl -fsSL "$OLD_ZIP_URL" -o "$WORK/old.zip"; then
+    if ! curl -fsSL "${CURL_RETRY[@]}" "$OLD_ZIP_URL" -o "$WORK/old.zip"; then
       echo "WARN: previous xcframework v${PREVIOUS_NATIVE} not available at clarity.ms — skipping diff" >&2
       emit_outputs 0 0 ""
       exit 0
@@ -110,7 +115,7 @@ case "$PLATFORM" in
 
     NEW_AAR_URL="https://repo1.maven.org/maven2/com/microsoft/clarity/clarity/${NEW_NATIVE}/clarity-${NEW_NATIVE}.aar"
     echo "==> Downloading new .aar: $NEW_AAR_URL"
-    if ! curl -fsSL "$NEW_AAR_URL" -o "$WORK/new.aar"; then
+    if ! curl -fsSL "${CURL_RETRY[@]}" "$NEW_AAR_URL" -o "$WORK/new.aar"; then
       echo "ERROR: could not download pinned .aar v${NEW_NATIVE} from Maven Central" >&2
       exit 1
     fi
@@ -118,7 +123,7 @@ case "$PLATFORM" in
 
     OLD_AAR_URL="https://repo1.maven.org/maven2/com/microsoft/clarity/clarity/${PREVIOUS_NATIVE}/clarity-${PREVIOUS_NATIVE}.aar"
     echo "==> Downloading previous .aar: $OLD_AAR_URL"
-    if ! curl -fsSL "$OLD_AAR_URL" -o "$WORK/old.aar"; then
+    if ! curl -fsSL "${CURL_RETRY[@]}" "$OLD_AAR_URL" -o "$WORK/old.aar"; then
       echo "ERROR: could not download baseline .aar v${PREVIOUS_NATIVE} from Maven Central" >&2
       exit 1
     fi

--- a/scripts/diff-binding-api.sh
+++ b/scripts/diff-binding-api.sh
@@ -97,27 +97,30 @@ case "$PLATFORM" in
     NEW_NATIVE=$(sed -n -E \
       's|.*<AndroidMavenLibrary +Include="com\.microsoft\.clarity:clarity" +Version="([^"]+)".*|\1|p' \
       src/Maui.MicrosoftClarity.Android/Maui.MicrosoftClarity.Android.csproj | head -1)
+    # Android bails hard rather than emitting 0/0 the way the iOS branch does:
+    # `emit_outputs 0 0` means "API surface verified unchanged", which is the exact
+    # condition automatic-bump-and-wire.yml auto-approves and auto-merges on. That is
+    # an acceptable fallback for iOS, where clarity.ms genuinely drops old
+    # xcframeworks, but Maven Central artifacts are immutable — a miss here is a
+    # network fault or a broken pin, never a legitimately absent artifact.
     if [[ -z "$NEW_NATIVE" ]]; then
-      echo "WARN: no <AndroidMavenLibrary> version in the Android csproj — skipping diff" >&2
-      emit_outputs 0 0 ""
-      exit 0
+      echo "ERROR: no <AndroidMavenLibrary> version found in the Android csproj" >&2
+      exit 1
     fi
 
     NEW_AAR_URL="https://repo1.maven.org/maven2/com/microsoft/clarity/clarity/${NEW_NATIVE}/clarity-${NEW_NATIVE}.aar"
     echo "==> Downloading new .aar: $NEW_AAR_URL"
     if ! curl -fsSL "$NEW_AAR_URL" -o "$WORK/new.aar"; then
-      echo "WARN: .aar v${NEW_NATIVE} not on Maven Central — skipping diff" >&2
-      emit_outputs 0 0 ""
-      exit 0
+      echo "ERROR: could not download pinned .aar v${NEW_NATIVE} from Maven Central" >&2
+      exit 1
     fi
     NEW_AAR="$WORK/new.aar"
 
     OLD_AAR_URL="https://repo1.maven.org/maven2/com/microsoft/clarity/clarity/${PREVIOUS_NATIVE}/clarity-${PREVIOUS_NATIVE}.aar"
     echo "==> Downloading previous .aar: $OLD_AAR_URL"
     if ! curl -fsSL "$OLD_AAR_URL" -o "$WORK/old.aar"; then
-      echo "WARN: previous .aar v${PREVIOUS_NATIVE} not on Maven Central — skipping diff" >&2
-      emit_outputs 0 0 ""
-      exit 0
+      echo "ERROR: could not download baseline .aar v${PREVIOUS_NATIVE} from Maven Central" >&2
+      exit 1
     fi
 
     if ! command -v javap >/dev/null 2>&1; then

--- a/src/Maui.MicrosoftClarity.Android/README.md
+++ b/src/Maui.MicrosoftClarity.Android/README.md
@@ -32,7 +32,7 @@ The versioning scheme of `Maui.MicrosoftClarity.Android` is derived from the ver
 	The AAR is downloaded when **this binding** is built and baked into the nupkg, so consumers
 	need no Java, no Gradle and no build-time downloads.
 - Then you have to add all necessary dependencies. Your binding library should contain all these dependencies (ideally in same `version` but until those libraries are compatible, versions are not important).
-  - I  have found and added `PackageReference` for all `Xamarin/Maui` alternatives of these libraries
+  - I have found and added `PackageReference` for all `Xamarin/Maui` alternatives of these libraries
 - The artifact's POM is downloaded alongside the AAR and drives **Java dependency verification**,
 	so a missing dependency now fails the build with `XA4241`/`XA4242` naming exactly what is
 	missing — the `PackageReference` list is cross-checked on every SDK bump instead of being


### PR DESCRIPTION
Follow-up to #38, addressing the Copilot review on that PR. **CI tooling and docs only — the published `Kebechet.Maui.MicrosoftClarity.Android` 3.8.2.1 package is unaffected.**

## 1. `diff-binding-api.sh` could auto-merge an unreviewed SDK bump

`emit_outputs 0 0` does not mean "couldn't tell" — it means *"API surface verified unchanged"*, which is the exact condition `automatic-bump-and-wire.yml` auto-approves and auto-merges on:

```yaml
needs.build.outputs.api_added_count == '0' && needs.build.outputs.api_removed_count == '0'
```

So a transient Maven Central failure during the diff step would have landed an SDK bump with no review. #38 made this materially more likely by turning the new-AAR input from a committed file into a network fetch.

Both the new and the baseline Android downloads are now hard failures. That fails the `build` job, which routes the PR down the `decide` job's @copilot branch instead of the auto-merge one.

The **iOS** soft-fails are deliberately untouched: clarity.ms really does drop old xcframeworks, so an absent artifact is an expected condition there. Maven Central artifacts are immutable, so a miss is always a fault. That asymmetry is now written down in the script.

## 2. `automatic-detect-sdk-updates.yml` opened a bogus PR daily on a failed parse

An empty `VERSION` compares unequal to every upstream version, so `needs_bump=true` fires forever. Now fatal.

Worth noting this hole **predates #38** rather than being introduced by it — the old code was equally exposed:

```bash
AAR=$(ls src/Maui.MicrosoftClarity.Android/Jars/clarity-*.aar | head -1)
VERSION=$(basename "$AAR" .aar | sed 's/^clarity-//')
```

Both are pipelines, so the assignment takes its exit status from `head`/`sed`, never from the failing `ls`/`basename`. `set -e` never fired and `VERSION` came out just as empty.

## 3. `bump-android.sh` now reads the pin back after writing it

Defensive rather than a live bug — step 1 already hard-exits when the same regex can't read the pin, so the write is unreachable with a non-matching pattern. Added anyway because this script publishes packages unattended, and the failure mode (bumping the NuGet version and wrapper reference while leaving the native pin behind) would ship a mislabelled package.

## 4. Stray double space in the Android README

Pre-existing; it lands in the packaged README.

## Verification

| Check | Result |
|---|---|
| `bump-android.sh 3.8.3` | still bumps pin + `<Version>` → `3.8.3.0` + wrapper reference |
| `bump-android.sh` with the pin reformatted onto two lines | refuses, exit 1 |
| `diff-binding-api.sh android 3.8.1.0` | 2936 added / 6065 removed, unchanged |
| `diff-binding-api.sh android 99.99.99.0` | exit 1 (previously a silent `0/0` + exit 0) |