### PR TITLE
ci: fix the wrapper build so bump PRs can actually reach auto-merge

### DIFF
--- a/.github/workflows/automatic-bump-and-wire.yml
+++ b/.github/workflows/automatic-bump-and-wire.yml
@@ -192,6 +192,11 @@ jobs:
           else
             TFM=net10.0-android
           fi
+          # The `| tee` below does not swallow a dotnet failure: `shell: bash` makes
+          # GitHub invoke `bash --noprofile --norc -e -o pipefail`, so the pipeline
+          # exits with dotnet's status rather than tee's. Dropping `shell: bash` here
+          # would silently turn every failed wrapper build into a green step.
+          #
           # The local feed MUST be an absolute path. NuGet resolves every --source
           # relative to the project directory once any one of them is relative, which
           # turns the nuget.org URL into '<projdir>\https:\api.nuget.org\v3\index.json'

--- a/.github/workflows/automatic-bump-and-wire.yml
+++ b/.github/workflows/automatic-bump-and-wire.yml
@@ -169,8 +169,10 @@ jobs:
           else
             PROJ=src/Maui.MicrosoftClarity.Android/Maui.MicrosoftClarity.Android.csproj
           fi
-          dotnet pack "$PROJ" -c ${{ env.BUILD_CONFIGURATION }} -o ./local-feed --no-build
-          dotnet nuget add source "$(pwd)/local-feed" --name local-bump || true
+          # $GITHUB_WORKSPACE, not $(pwd): on the windows-latest runner this step uses
+          # Git Bash, whose $(pwd) is an MSYS path (/d/a/...) that the Windows dotnet
+          # CLI rejects outright. The wrapper step consumes this feed by absolute path.
+          dotnet pack "$PROJ" -c ${{ env.BUILD_CONFIGURATION }} -o "$GITHUB_WORKSPACE/local-feed" --no-build
 
       # ---- Build the wrapper --------------------------------------------
       # Only the bumped platform's TFM is relevant — the other TFMs consume
@@ -190,25 +192,18 @@ jobs:
           else
             TFM=net10.0-android
           fi
+          # The local feed MUST be an absolute path. NuGet resolves every --source
+          # relative to the project directory once any one of them is relative, which
+          # turns the nuget.org URL into '<projdir>\https:\api.nuget.org\v3\index.json'
+          # and fails the restore with NU1301 - the wrapper then looks "broken" on
+          # every single bump PR and the run can never reach the auto-merge path.
           dotnet restore src/Maui.MicrosoftClarity/Maui.MicrosoftClarity.csproj \
             -p:TargetFrameworks="$TFM" \
-            --source ./local-feed --source https://api.nuget.org/v3/index.json
+            --source "$GITHUB_WORKSPACE/local-feed" \
+            --source https://api.nuget.org/v3/index.json 2>&1 | tee wrapper-build.log
           dotnet build   src/Maui.MicrosoftClarity/Maui.MicrosoftClarity.csproj \
             -p:TargetFrameworks="$TFM" \
-            -c ${{ env.BUILD_CONFIGURATION }} --no-restore
-
-      - if: steps.build_wrapper.outcome != 'success'
-        name: Capture wrapper build log
-        shell: bash
-        run: |
-          if [[ "${{ needs.guard.outputs.platform }}" == "ios" ]]; then
-            TFM=net10.0-ios
-          else
-            TFM=net10.0-android
-          fi
-          dotnet build src/Maui.MicrosoftClarity/Maui.MicrosoftClarity.csproj \
-            -p:TargetFrameworks="$TFM" \
-            -c ${{ env.BUILD_CONFIGURATION }} 2>&1 | tee wrapper-build.log || true
+            -c ${{ env.BUILD_CONFIGURATION }} --no-restore 2>&1 | tee -a wrapper-build.log
 
       - if: steps.build_wrapper.outcome != 'success'
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Every Android and iOS bump PR has been failing the wrapper step and posting a false *"the SDK bump introduced a breaking change"* @copilot ping. #36 got it in June and again today. The SDK was never the problem.

## Root cause

```bash
dotnet restore … --source ./local-feed --source https://api.nuget.org/v3/index.json
```

Once **any** `--source` is relative, NuGet resolves all of them relative to the project directory, so the nuget.org URL becomes a path:

```
error NU1301: The local source
'D:\a\…\src\Maui.MicrosoftClarity\https:\api.nuget.org\v3\index.json' doesn't exist.
```

Reproduced locally against this exact repo:

| `--source` form | Result |
|---|---|
| `./local-feed` + nuget.org URL | `NU1301`, nuget.org URL mangled into a path |
| absolute path + nuget.org URL | `Restored … (in 178 ms)` |

## Why it stayed hidden for months

- `dotnet nuget add source "$(pwd)/local-feed"` fails on the `windows-latest` runner: Git Bash's `$(pwd)` is an MSYS path (`/d/a/…`) that the Windows dotnet CLI rejects outright — `error: The source specified is invalid`, swallowed by `|| true`. That line is dead weight now that the feed is passed explicitly, so it's removed.
- The separate **`Capture wrapper build log`** step re-ran the build *without* the local feed, so the uploaded artifact showed a bogus `NU1102` about the unpublished binding version instead of the real `NU1301`. Anyone reading the artifact would conclude the binding just wasn't published yet. The capture is now a `tee` inside the step itself — matching what the binding step already does — so the artifact shows what actually happened.

## Consequence

The `decide` job's stable path requires `wrapper_built == 'true'`, so **no bump PR could ever auto-merge**; every one fell through to the wrapper-broken @copilot branch.

Worth flagging: the API diff artifact for the 3.8.2 → 3.8.3 bump in #36 is **0 bytes, 0 additions, 0 removals**. That PR should have auto-approved and auto-merged on its own, and its `needs-wiring` label is spurious both times it was applied.

## Verification

- Both workflow files parse as YAML.
- All 13 `run:` blocks pass `bash -n` under Git Bash (the shell the Windows runner actually uses).
- The restore fix is verified locally, both the failing and the passing form.

The real end-to-end proof is re-running the pipeline on #36 once this lands.